### PR TITLE
Implement timed overlay on GPIO trigger

### DIFF
--- a/node.lua
+++ b/node.lua
@@ -8,17 +8,34 @@ local video = resource.load_video{
 
 local overlay = resource.load_image("overlay.png")
 
-local show_overlay = false
+-- This will store the time when the overlay was shown.
+-- It's nil if the overlay is not currently shown.
+local overlay_shown_at = nil
 
 util.data_mapper{
     ["gpio/18"] = function(value)
-        show_overlay = (value == "1")
+        -- The value is "1" when the button is pressed.
+        -- We only want to trigger this once when the button is pressed,
+        -- so we also check if the overlay is not already being shown.
+        if value == "1" and not overlay_shown_at then
+            overlay_shown_at = util.time()
+        end
     end
 }
 
 function node.render()
+    -- Always draw the video in the background
     video:draw(0, 0, WIDTH, HEIGHT)
-    if show_overlay then
-        overlay:draw(0, 0, WIDTH, HEIGHT)
+
+    -- Check if the overlay should be shown
+    if overlay_shown_at then
+        -- Check if 5 minutes (300 seconds) have passed
+        if util.time() - overlay_shown_at > 300 then
+            -- Time's up. Hide the overlay by resetting our variable
+            overlay_shown_at = nil
+        else
+            -- 5 minutes have not passed yet. Keep showing the overlay.
+            overlay:draw(0, 0, WIDTH, HEIGHT)
+        end
     end
 end


### PR DESCRIPTION
This change modifies the info-beamer package to display an overlay image for 5 minutes when GPIO pin 18 is triggered.

The previous implementation showed the overlay only while the GPIO pin was held high. This commit introduces a timer-based approach. When the GPIO pin is pressed, a timestamp is recorded. The overlay is displayed until 300 seconds have passed, after which it is hidden automatically.